### PR TITLE
Improve config security and leverage defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Hyper-Trading Automation
 
 This project implements a simplified version of the trading automation system described in the accompanying design document.
+It is a research prototype intended for educational purposes rather than a
+production‑grade or high‑frequency trading engine.
 
 ## Features
 
@@ -55,9 +57,19 @@ pip install -r requirements.txt
 
 ### Configuration
 
-Runtime options such as API keys, default trading symbol and risk parameters
-are stored in `config.yaml`. Edit this file to suit your environment or pass a
-custom path to the bot using `--config`.
+Runtime options such as default trading symbols and risk parameters are stored
+in `config.yaml`. A `config.sample.yaml` is provided as a template – copy it to
+`config.yaml` and adjust values for your environment. API keys are **not**
+stored in the YAML file and should instead be supplied via environment
+variables:
+
+```bash
+export FRED_API_KEY=your_fred_key
+export NEWS_API_KEY=your_news_key
+export ETHERSCAN_API_KEY=your_etherscan_key
+```
+
+You may also pass a custom config path to the bot using `--config`.
 
 2. Run tests:
 

--- a/config.sample.yaml
+++ b/config.sample.yaml
@@ -1,0 +1,9 @@
+trading:
+  exchange: binance
+  symbols: ["BTC/USDT"]
+  account_balance: 100.0
+  risk_percent: 5.0
+  max_exposure: 3.0
+
+# API keys are read from environment variables:
+#   FRED_API_KEY, NEWS_API_KEY, ETHERSCAN_API_KEY

--- a/hypertrader/config.py
+++ b/hypertrader/config.py
@@ -7,6 +7,7 @@ at the project root is used when no path is provided.
 
 from __future__ import annotations
 
+import os
 from pathlib import Path
 from typing import Any, Dict
 
@@ -68,6 +69,13 @@ def load_config(path: str | Path | None = None) -> Dict[str, Any]:
             model = ConfigModel.parse_obj(data)
     except ValidationError as exc:  # pragma: no cover - simple pass through
         raise ValueError(f"Invalid configuration: {exc}") from exc
+
+    # Fill API keys from environment variables if not provided in config
+    api = model.api_keys or APIKeys()
+    api.fred = api.fred or os.getenv("FRED_API_KEY")
+    api.news = api.news or os.getenv("NEWS_API_KEY")
+    api.etherscan = api.etherscan or os.getenv("ETHERSCAN_API_KEY")
+    model.api_keys = api
 
     return model.model_dump() if hasattr(model, "model_dump") else model.dict()
 

--- a/hypertrader/utils/risk.py
+++ b/hypertrader/utils/risk.py
@@ -102,8 +102,8 @@ def dynamic_leverage(
     capital: float,
     risk_percent: float = 1.0,
     volatility: float = 0.02,
-    min_leverage: float = 10.0,
-    max_leverage: float = 100.0,
+    min_leverage: float = 1.0,
+    max_leverage: float = 5.0,
 ) -> float:
     """Determine leverage based on risk tolerance and market volatility.
 
@@ -115,9 +115,9 @@ def dynamic_leverage(
         Percentage of capital willing to risk on a trade.
     volatility : float, default 0.02
         Recent volatility estimate expressed as a decimal (e.g. ``0.02`` for 2%).
-    min_leverage : float, default 10.0
+    min_leverage : float, default 1.0
         Minimum leverage allowed by the broker.
-    max_leverage : float, default 100.0
+    max_leverage : float, default 5.0
         Maximum leverage allowed by the broker.
 
     Returns

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -16,3 +16,12 @@ def test_load_config(tmp_path: Path):
     loaded = load_config(path)
     assert loaded["trading"]["symbol"] == "BTC-USD"
     assert loaded["trading"]["risk_percent"] == 1.0
+
+
+def test_env_api_keys(monkeypatch, tmp_path: Path):
+    cfg = {"trading": {"symbol": "BTC-USD", "risk_percent": 1.0}}
+    path = tmp_path / "config.yaml"
+    path.write_text(yaml.safe_dump(cfg))
+    monkeypatch.setenv("FRED_API_KEY", "ENVKEY")
+    loaded = load_config(path)
+    assert loaded["api_keys"]["fred"] == "ENVKEY"

--- a/tests/test_risk.py
+++ b/tests/test_risk.py
@@ -40,8 +40,8 @@ def test_kill_switch():
 
 def test_dynamic_leverage():
     lev = dynamic_leverage(100, risk_percent=1, volatility=0.0005)
-    assert 10 <= lev <= 100
-    assert lev > 10  # should scale above minimum with low vol
+    assert 1 <= lev <= 5
+    assert lev > 1  # should scale above minimum with low vol
 
 
 def test_compound_and_vol_stop():


### PR DESCRIPTION
## Summary
- load API keys from environment variables when absent in config files
- add `config.sample.yaml` template and document secure config usage
- tighten `dynamic_leverage` defaults to 1-5x to encourage conservative risk

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689595c835e48322b1a53b2787b1f7bd