### PR TITLE
Introduce event-driven trading pipeline with risk and order management

### DIFF
--- a/hypertrader/core/__init__.py
+++ b/hypertrader/core/__init__.py
@@ -1,0 +1,1 @@
+"""Core event-driven trading engine components."""

--- a/hypertrader/core/pipeline.py
+++ b/hypertrader/core/pipeline.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+from typing import Protocol, AsyncIterator, Dict, Any
+
+
+class DataFeed(Protocol):
+    """Protocol for async market data feeds."""
+
+    async def stream(self) -> AsyncIterator[Dict[str, Any]]:
+        ...
+
+
+class Strategy(Protocol):
+    """Protocol for strategy components producing trade signals."""
+
+    def on_tick(self, tick: Dict[str, Any]) -> Dict[str, Any] | None:
+        ...
+
+
+class RiskGate(Protocol):
+    """Protocol for pre-trade risk checks."""
+
+    def check_order(self, equity: float, position_value: float, edge: float) -> bool:
+        ...
+
+
+class OrderExecutor(Protocol):
+    """Protocol for order execution components."""
+
+    async def execute(self, signal: Dict[str, Any]) -> None:
+        ...
+
+
+class Pipeline:
+    """Event-driven trading pipeline combining feed, strategy, risk and execution."""
+
+    def __init__(
+        self,
+        feed: DataFeed,
+        strategy: Strategy,
+        risk: RiskGate,
+        executor: OrderExecutor,
+    ) -> None:
+        self.feed = feed
+        self.strategy = strategy
+        self.risk = risk
+        self.executor = executor
+
+    async def run(self, equity: float) -> None:
+        """Continuously process ticks from the data feed."""
+        async for tick in self.feed.stream():
+            signal = self.strategy.on_tick(tick)
+            if not signal:
+                continue
+            notional = float(signal.get("notional", 0))
+            edge = float(signal.get("edge", 0))
+            if not self.risk.check_order(equity, notional, edge):
+                continue
+            await self.executor.execute(signal)

--- a/hypertrader/execution/__init__.py
+++ b/hypertrader/execution/__init__.py
@@ -1,0 +1,1 @@
+"""Execution layer and order management."""

--- a/hypertrader/execution/order_manager.py
+++ b/hypertrader/execution/order_manager.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum, auto
+from typing import Dict
+
+
+class OrderState(Enum):
+    """Lifecycle states for an order."""
+
+    PENDING = auto()
+    OPEN = auto()
+    PARTIAL = auto()
+    FILLED = auto()
+    CANCELED = auto()
+
+
+@dataclass(slots=True)
+class Order:
+    """Simple order representation used by :class:`OrderManager`."""
+
+    id: str
+    symbol: str
+    side: str
+    quantity: float
+    filled: float = 0.0
+    state: OrderState = field(default=OrderState.PENDING)
+
+
+class OrderManager:
+    """Track and update order state in response to execution events."""
+
+    def __init__(self) -> None:
+        self.orders: Dict[str, Order] = {}
+
+    def submit(self, order: Order) -> None:
+        """Register a new order in ``PENDING`` state."""
+        self.orders[order.id] = order
+
+    def on_ack(self, order_id: str) -> None:
+        """Mark the order as acknowledged/open."""
+        if order_id in self.orders:
+            self.orders[order_id].state = OrderState.OPEN
+
+    def on_fill(self, order_id: str, quantity: float) -> None:
+        """Update filled quantity and state based on fills."""
+        order = self.orders.get(order_id)
+        if not order:
+            return
+        order.filled += quantity
+        if order.filled >= order.quantity:
+            order.state = OrderState.FILLED
+        else:
+            order.state = OrderState.PARTIAL
+
+    def on_cancel(self, order_id: str) -> None:
+        """Mark an order as canceled."""
+        if order_id in self.orders:
+            self.orders[order_id].state = OrderState.CANCELED
+
+    def cancel_all(self) -> None:
+        """Cancel all outstanding orders."""
+        for order in self.orders.values():
+            if order.state not in (OrderState.FILLED, OrderState.CANCELED):
+                order.state = OrderState.CANCELED

--- a/hypertrader/feeds/__init__.py
+++ b/hypertrader/feeds/__init__.py
@@ -1,0 +1,1 @@
+"""Data feed implementations."""

--- a/hypertrader/feeds/ccxt_ws.py
+++ b/hypertrader/feeds/ccxt_ws.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import asyncio
+from typing import AsyncIterator, Dict
+
+try:  # pragma: no cover - optional dependency
+    import ccxt.pro as ccxtpro
+except Exception:  # pragma: no cover - handled gracefully during tests
+    ccxtpro = None
+
+
+class CCXTWebSocketFeed:
+    """Simple WebSocket market data feed using ``ccxt.pro``.
+
+    Parameters
+    ----------
+    exchange : str
+        Exchange identifier supported by ``ccxt.pro`` (e.g. ``"binance"``).
+    symbol : str
+        Trading symbol in ``BASE/QUOTE`` format.
+    """
+
+    def __init__(self, exchange: str, symbol: str) -> None:
+        if ccxtpro is None:
+            raise RuntimeError("ccxt.pro is required for WebSocket feed support")
+        self.exchange_name = exchange
+        self.symbol = symbol
+        self.client = getattr(ccxtpro, exchange)()
+
+    async def stream(self) -> AsyncIterator[Dict]:
+        """Yield ticker updates indefinitely."""
+        while True:
+            tick = await self.client.watch_ticker(self.symbol)
+            yield tick
+
+    async def close(self) -> None:
+        """Close the underlying WebSocket connection."""
+        await self.client.close()

--- a/hypertrader/risk/__init__.py
+++ b/hypertrader/risk/__init__.py
@@ -1,0 +1,1 @@
+"""Risk management modules."""

--- a/hypertrader/risk/manager.py
+++ b/hypertrader/risk/manager.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(slots=True)
+class RiskParams:
+    """Configuration controlling pre-trade risk checks."""
+
+    max_daily_loss: float
+    """Absolute loss in account currency that triggers trading halt."""
+
+    max_position: float
+    """Maximum allowed notional exposure per order."""
+
+    fee_rate: float = 0.0
+    """Estimated taker fee rate used to sanity-check signal edge."""
+
+
+class RiskManager:
+    """Simple risk gate evaluated before every order.
+
+    The manager keeps track of starting equity for the day and ensures
+    that new orders respect exposure limits and halt trading once the
+    daily loss limit has been reached.
+    """
+
+    def __init__(self, params: RiskParams) -> None:
+        self.params = params
+        self.starting_equity: float | None = None
+
+    def reset_day(self, equity: float) -> None:
+        """Reset the starting equity, typically at the beginning of a session."""
+        self.starting_equity = equity
+
+    def check_order(self, equity: float, position_value: float, edge: float) -> bool:
+        """Return ``True`` if the order passes all risk checks."""
+        if self.starting_equity is None:
+            self.reset_day(equity)
+        loss = self.starting_equity - equity
+        if loss > self.params.max_daily_loss:
+            return False
+        if position_value > self.params.max_position:
+            return False
+        if edge <= self.params.fee_rate:
+            return False
+        return True

--- a/tests/test_order_manager_state.py
+++ b/tests/test_order_manager_state.py
@@ -1,0 +1,26 @@
+from hypertrader.execution.order_manager import OrderManager, Order, OrderState
+
+
+def test_state_transitions() -> None:
+    om = OrderManager()
+    order = Order(id="1", symbol="BTC/USDT", side="buy", quantity=1)
+    om.submit(order)
+    assert om.orders["1"].state is OrderState.PENDING
+    om.on_ack("1")
+    assert om.orders["1"].state is OrderState.OPEN
+    om.on_fill("1", 0.4)
+    assert om.orders["1"].state is OrderState.PARTIAL
+    om.on_fill("1", 0.6)
+    assert om.orders["1"].state is OrderState.FILLED
+
+
+def test_cancel_all() -> None:
+    om = OrderManager()
+    o1 = Order(id="1", symbol="X", side="buy", quantity=1)
+    o2 = Order(id="2", symbol="X", side="buy", quantity=1)
+    om.submit(o1)
+    om.submit(o2)
+    om.on_ack("1")
+    om.cancel_all()
+    assert om.orders["1"].state is OrderState.CANCELED
+    assert om.orders["2"].state is OrderState.CANCELED

--- a/tests/test_risk_manager_limits.py
+++ b/tests/test_risk_manager_limits.py
@@ -1,0 +1,16 @@
+from hypertrader.risk.manager import RiskManager, RiskParams
+
+
+def test_daily_loss_limit() -> None:
+    rm = RiskManager(RiskParams(max_daily_loss=100, max_position=1000, fee_rate=0.001))
+    rm.reset_day(1000)
+    assert rm.check_order(950, 100, 0.002)
+    assert not rm.check_order(800, 100, 0.002)
+
+
+def test_exposure_and_fee_checks() -> None:
+    rm = RiskManager(RiskParams(max_daily_loss=100, max_position=500, fee_rate=0.001))
+    rm.reset_day(1000)
+    assert not rm.check_order(1000, 600, 0.005)
+    assert not rm.check_order(1000, 100, 0.0005)
+    assert rm.check_order(1000, 100, 0.005)


### PR DESCRIPTION
## Summary
- add event-driven `Pipeline` protocol layer tying together feed, strategy, risk, and execution
- implement `RiskManager` with daily loss, exposure, and fee edge checks
- introduce `OrderManager` state machine for order lifecycle tracking
- provide ccxt.pro WebSocket feed wrapper and unit tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6895a111d4688322b2a778332d8089a2