### PR TITLE
Add basic risk checks and order validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 This project implements a simplified version of the trading automation system described in the accompanying design document.
 It is a research prototype intended for educational purposes rather than a
 production‑grade or high‑frequency trading engine.
+See [docs/production_readiness.md](docs/production_readiness.md) for known gaps and steps required before live trading.
 
 ## Features
 

--- a/docs/production_readiness.md
+++ b/docs/production_readiness.md
@@ -1,0 +1,34 @@
+# Production Readiness Recommendations
+
+This repository is a research prototype and is **not** production-ready for live or high-frequency trading. The checklist below captures the major gaps that must be addressed before considering real-money deployment.
+
+## Architecture weaknesses
+- Polling-first pipeline with optional WebSocket support. Production systems should use WebSockets end-to-end, feeding an event-driven signal generator and order management system (OMS).
+- MT5 bridge communicates via `signal.json`; replace file I/O with direct exchange APIs or a persistent IPC channel.
+- No hardened OMS. Implement idempotent `clientOrderId`, state transitions (`NEW`, `ACK`, `PARTIAL`, `FILLED`, `CANCELED`), retries and persistence for crash recovery.
+
+## Risk-control gaps
+- Basic pre-send validation for venue rules (minimum notional and step size) has been added, but post-only and reduce-only flags remain unhandled.
+- Fee and slippage-aware edge checks implemented via ``RiskManager``; still need latency/slippage circuit breakers.
+- Circuit breakers: daily loss caps and per-symbol exposure limits exist, yet cancel-all on disconnect and latency breakers are still missing.
+
+## Backtesting limitations
+- Vectorized backtests do not model order book microstructure or latency. Use an event-driven simulator with depth, queue and realistic fills.
+- Current data sources (e.g., Yahoo Finance) are informational only. Replace with exchange-grade historical data.
+- Include actual fees and funding costs in simulations.
+
+## Prioritized fixes
+1. Make WebSocket ingestion the default and instrument latency metrics (tick→decision, decision→ack, ack→fill).
+2. Implement a persistent OMS with cancel-on-disconnect and reduce-only/post-only enforcement.
+3. Remove the file-based MT5 bridge and execute directly against exchange APIs or a dedicated execution service.
+4. Upgrade the backtesting engine to model depth, queue position, latency and fees.
+5. Purge Yahoo Finance from live decision paths; use exchange APIs or paid feeds for both live and historical data.
+6. Tune rate limits and reconnection logic per venue with explicit tests.
+7. Add fee/funding-aware gating to avoid trades with negative expected edge.
+
+## Deployment checklist
+- **Paper / shadow trading**: verify WebSocket stability, simulate OMS flows, and test circuit breakers.
+- **Small live trading**: enable post-only where possible, enforce exposure limits and a kill-switch.
+- **Scale up** only after demonstrating stability over at least 30 sessions per venue and symbol.
+
+These steps will help evolve the project from a prototype into a robust automation system.

--- a/hypertrader/execution/ccxt_executor.py
+++ b/hypertrader/execution/ccxt_executor.py
@@ -5,6 +5,8 @@ import time
 
 import ccxt.async_support as ccxt
 
+from .validators import validate_order
+
 ex = getattr(ccxt, os.getenv("EXCHANGE", "binance"))({
     "apiKey": os.getenv("API_KEY"),
     "secret": os.getenv("API_SECRET"),
@@ -12,11 +14,27 @@ ex = getattr(ccxt, os.getenv("EXCHANGE", "binance"))({
 })
 
 
-async def place_order(symbol: str, side: str, qty: float, price: float | None = None, params: dict | None = None):
+async def place_order(
+    symbol: str, side: str, qty: float, price: float | None = None, params: dict | None = None
+):
+    """Place an order after validating venue limits."""
+
     params = params or {}
-    fn = ex.create_limit_buy_order if side == "buy" else ex.create_limit_sell_order
-    before = time.perf_counter()
-    order = await fn(symbol, qty, price, params)
+
+    await ex.load_markets()
+    market = ex.market(symbol)
+    if price is not None:
+        if not validate_order(price, qty, market):
+            raise ValueError("Order violates market limits")
+        fn = ex.create_limit_buy_order if side == "buy" else ex.create_limit_sell_order
+        before = time.perf_counter()
+        order = await fn(symbol, qty, price, params)
+    else:
+        if not validate_order(0.0, qty, market):
+            raise ValueError("Order violates market limits")
+        fn = ex.create_market_buy_order if side == "buy" else ex.create_market_sell_order
+        before = time.perf_counter()
+        order = await fn(symbol, qty, params)
     latency_ms = (time.perf_counter() - before) * 1000
     logging.info("order-latency-ms %d", latency_ms)
     return order

--- a/hypertrader/execution/validators.py
+++ b/hypertrader/execution/validators.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import math
+from typing import Dict, Any
+
+
+def validate_order(price: float, quantity: float, market: Dict[str, Any]) -> bool:
+    """Return ``True`` if the order satisfies basic venue limits.
+
+    Parameters
+    ----------
+    price:
+        Order price. Used to compute notional for cost limits.
+    quantity:
+        Order quantity in base currency.
+    market:
+        Market metadata from CCXT, expected to contain ``limits`` with
+        ``amount`` and ``cost`` entries.
+    """
+
+    limits = market.get("limits", {})
+    amount = limits.get("amount", {})
+    cost = limits.get("cost", {})
+
+    min_amount = amount.get("min")
+    step = amount.get("step")
+    min_cost = cost.get("min")
+
+    if min_amount is not None and quantity < min_amount:
+        return False
+
+    if step is not None:
+        ratio = quantity / step
+        if not math.isclose(ratio, round(ratio), rel_tol=0, abs_tol=1e-8):
+            return False
+
+    if min_cost is not None and price * quantity < min_cost:
+        return False
+
+    return True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 requires-python = ">=3.11,<4.0"
 dependencies = [
     "ccxt==4.3.22",
-    "cryptofeed==2.3.0",
+    "cryptofeed==2.4.1",
     "websockets==12.0",
 ]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 ccxt==4.3.22
+cryptofeed==2.4.1
 pandas==2.2.2
 vaderSentiment==3.3.2
 requests==2.32.3

--- a/tests/test_order_validation.py
+++ b/tests/test_order_validation.py
@@ -1,0 +1,13 @@
+from hypertrader.execution.validators import validate_order
+
+
+def test_validate_order_limits() -> None:
+    market = {
+        "limits": {
+            "amount": {"min": 0.001, "step": 0.001},
+            "cost": {"min": 10},
+        }
+    }
+    assert not validate_order(20000, 0.0004, market)
+    assert not validate_order(20000, 0.0015, market)
+    assert validate_order(20000, 0.001, market)

--- a/tests/test_risk_manager_limits.py
+++ b/tests/test_risk_manager_limits.py
@@ -2,15 +2,25 @@ from hypertrader.risk.manager import RiskManager, RiskParams
 
 
 def test_daily_loss_limit() -> None:
-    rm = RiskManager(RiskParams(max_daily_loss=100, max_position=1000, fee_rate=0.001))
+    rm = RiskManager(
+        RiskParams(max_daily_loss=100, max_position=1000, fee_rate=0.001, slippage=0.0005)
+    )
     rm.reset_day(1000)
-    assert rm.check_order(950, 100, 0.002)
-    assert not rm.check_order(800, 100, 0.002)
+    assert rm.check_order(950, "BTC-USD", 100, 0.002)
+    assert not rm.check_order(800, "BTC-USD", 100, 0.002)
 
 
-def test_exposure_and_fee_checks() -> None:
-    rm = RiskManager(RiskParams(max_daily_loss=100, max_position=500, fee_rate=0.001))
+def test_exposure_fee_slippage_and_symbol_limit() -> None:
+    params = RiskParams(
+        max_daily_loss=100,
+        max_position=500,
+        fee_rate=0.001,
+        slippage=0.0005,
+        symbol_limits={"ETH-USD": 300},
+    )
+    rm = RiskManager(params)
     rm.reset_day(1000)
-    assert not rm.check_order(1000, 600, 0.005)
-    assert not rm.check_order(1000, 100, 0.0005)
-    assert rm.check_order(1000, 100, 0.005)
+    assert not rm.check_order(1000, "ETH-USD", 600, 0.005)
+    assert not rm.check_order(1000, "ETH-USD", 200, 0.001)
+    assert not rm.check_order(1000, "ETH-USD", 400, 0.005)
+    assert rm.check_order(1000, "BTC-USD", 200, 0.005)


### PR DESCRIPTION
## Summary
- Enforce exchange min-notional and step-size requirements through a new validator wired into the CCXT executor
- Expand RiskManager with slippage-aware edge checks and per-symbol exposure caps
- Update production readiness guide to reflect newly implemented risk controls
- Include cryptofeed dependency so real-time feed tests run out of the box

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6895a884f12c8322abe86f9d288f4fa0