### PR TITLE
Improve lint and type safety across trading system

### DIFF
--- a/hypertrader/bot.py
+++ b/hypertrader/bot.py
@@ -64,7 +64,7 @@ def run(
     model_path: str | None = None,
     signal_path: str = "signal.json",
     config_path: str | None = None,
-    state_path: str | None = None,
+    state_path: str | Path | None = None,
     exchange: str | None = None,
     etherscan_api_key: str | None = None,
     max_exposure: float = 3.0,

--- a/hypertrader/core/pipeline.py
+++ b/hypertrader/core/pipeline.py
@@ -6,7 +6,7 @@ from typing import Protocol, AsyncIterator, Dict, Any
 class DataFeed(Protocol):
     """Protocol for async market data feeds."""
 
-    async def stream(self) -> AsyncIterator[Dict[str, Any]]:
+    def stream(self) -> AsyncIterator[Dict[str, Any]]:
         ...
 
 

--- a/hypertrader/data/feeds.py
+++ b/hypertrader/data/feeds.py
@@ -1,10 +1,10 @@
 import asyncio
-import logging
+from typing import Any
 from cryptofeed import FeedHandler
 from cryptofeed.defines import TRADES, TICKER
 from cryptofeed.exchanges import Binance, Coinbase, Kraken
 
-QUEUE = asyncio.Queue(maxsize=10000)
+QUEUE: asyncio.Queue[Any] = asyncio.Queue(maxsize=10000)
 
 def _cb(feed, pair, order):
     asyncio.create_task(QUEUE.put(order))

--- a/hypertrader/execution/ccxt_executor.py
+++ b/hypertrader/execution/ccxt_executor.py
@@ -1,4 +1,3 @@
-import asyncio
 import logging
 import os
 import time

--- a/hypertrader/execution/fix.py
+++ b/hypertrader/execution/fix.py
@@ -12,7 +12,7 @@ except Exception:  # pragma: no cover - quickfix not installed
     fix = None  # type: ignore
 
 
-class FIXApp(fix.Application if fix else object):
+class FIXApp(fix.Application if fix else object):  # type: ignore[misc]
     """Basic FIX application skeleton.
 
     The class only defines callbacks required by ``quickfix``. If the

--- a/hypertrader/feeds/ccxt_ws.py
+++ b/hypertrader/feeds/ccxt_ws.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import asyncio
 from typing import AsyncIterator, Dict
 
 try:  # pragma: no cover - optional dependency

--- a/hypertrader/orchestrator.py
+++ b/hypertrader/orchestrator.py
@@ -1,7 +1,7 @@
 """Central orchestration for the trading system."""
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Any, Dict, Optional
 import time
 

--- a/hypertrader/risk/manager.py
+++ b/hypertrader/risk/manager.py
@@ -46,6 +46,7 @@ class RiskManager:
 
         if self.starting_equity is None:
             self.reset_day(equity)
+            assert self.starting_equity is not None
 
         loss = self.starting_equity - equity
         if loss > self.params.max_daily_loss:

--- a/hypertrader/strategies/advanced_ml_strategy.py
+++ b/hypertrader/strategies/advanced_ml_strategy.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 """Advanced machine learning utilities for hyper-trading.
 
 This module introduces a more complex ML pipeline including feature
@@ -8,6 +6,8 @@ reinforcement learning environment.  The goal is to provide an easily
 extensible baseline for high frequency trading research without imposing
 heavy runtime costs on users that do not require the functionality.
 """
+
+from __future__ import annotations
 
 from typing import Iterable, Tuple
 

--- a/hypertrader/strategies/hft_transformer.py
+++ b/hypertrader/strategies/hft_transformer.py
@@ -1,6 +1,6 @@
-from __future__ import annotations
-
 """Transformer-based model for high-frequency trading predictions."""
+
+from __future__ import annotations
 
 from dataclasses import dataclass
 from typing import Optional

--- a/hypertrader/strategies/leverage_rl.py
+++ b/hypertrader/strategies/leverage_rl.py
@@ -1,6 +1,6 @@
-from __future__ import annotations
-
 """Reinforcement-learning helpers for dynamic leverage selection."""
+
+from __future__ import annotations
 
 from dataclasses import dataclass
 from typing import Tuple
@@ -27,7 +27,7 @@ class EnvConfig:
 class CustomTradingEnv(Env):
     """Minimal trading environment exposing leverage as an action."""
 
-    metadata = {"render.modes": []}
+    metadata: dict[str, list[str]] = {"render.modes": []}
 
     def __init__(self, config: EnvConfig | None = None):  # pragma: no cover - simple container
         self.config = config or EnvConfig()

--- a/hypertrader/strategies/ml_strategy.py
+++ b/hypertrader/strategies/ml_strategy.py
@@ -1,9 +1,8 @@
-from __future__ import annotations
-
 """Simple machine learning-based strategy utilities."""
 
+from __future__ import annotations
+
 from dataclasses import dataclass
-from typing import Optional
 
 import pandas as pd
 from sklearn.linear_model import LogisticRegression

--- a/hypertrader/strategies/multi_strategy.py
+++ b/hypertrader/strategies/multi_strategy.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 """Collection of simple multi-strategy helpers.
 
 The functions provided here serve as building blocks for arbitrage,
@@ -7,6 +5,8 @@ scalping and market-making strategies.  They are intentionally minimal
 and operate on the best-effort basis, serving as examples of how to
 extend the existing rule-based strategies in ``hypertrader``.
 """
+
+from __future__ import annotations
 
 from typing import Tuple
 
@@ -32,7 +32,6 @@ def arb_scalp(
     p1 = getattr(ccxt, primary_ex)().fetch_ticker(symbol)["last"]
     p2 = getattr(ccxt, secondary_ex)().fetch_ticker(symbol)["last"]
     if abs(p1 - p2) > threshold * p1:
-        size = (capital * lev * 0.01) / p1  # 1% of capital at given leverage
         return "buy_low_sell_high" if p1 < p2 else "sell_high_buy_low"
     return "neutral"
 

--- a/hypertrader/utils/prop.py
+++ b/hypertrader/utils/prop.py
@@ -1,6 +1,6 @@
-from __future__ import annotations
-
 """Utilities for simulating prop-trading style funding challenges."""
+
+from __future__ import annotations
 
 from dataclasses import dataclass
 from typing import Callable, Dict

--- a/hypertrader/utils/risk.py
+++ b/hypertrader/utils/risk.py
@@ -218,8 +218,8 @@ def drl_throttle(state: tuple[float, float]) -> float:
         sb3 = import_module("stable_baselines3")
         gym = import_module("gym")
         # Simple environment describing risk state
-        class RiskEnv(gym.Env):
-            metadata = {"render.modes": []}
+        class RiskEnv(gym.Env):  # type: ignore[name-defined]
+            metadata: dict[str, list[str]] = {"render.modes": []}
 
             def __init__(self):
                 super().__init__()

--- a/hypertrader/utils/volatility.py
+++ b/hypertrader/utils/volatility.py
@@ -76,7 +76,7 @@ def rank_symbols_by_volatility(
                 sym, atr = result
                 vol_map[sym] = atr
 
-    ranked = sorted(vol_map, key=vol_map.get, reverse=True)
+    ranked = sorted(vol_map, key=lambda k: vol_map.get(k, 0.0), reverse=True)
     return ranked
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,3 +20,7 @@ performance = ["uvloop==0.19.0", "ujson==5.9.0"]
 [build-system]
 requires = ["poetry-core>=2.0.0,<3.0.0"]
 build-backend = "poetry.core.masonry.api"
+
+[tool.mypy]
+ignore_missing_imports = true
+disable_error_code = ["import-untyped"]

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -1,5 +1,4 @@
 import json
-from pathlib import Path
 import pandas as pd
 
 from hypertrader.bot import run


### PR DESCRIPTION
## Summary
- remove unused imports and reorder module docstrings for lint compliance
- add mypy configuration and type hints for queues, risk env classes, and metadata
- refine pipeline protocol and risk manager to satisfy static type checks

## Testing
- `ruff check .`
- `mypy hypertrader`
- `pytest tests/test_backtest_framework.py::test_advanced_backtest -vv`
- `pytest tests/test_bot.py::test_run_creates_signal -vv`


------
https://chatgpt.com/codex/tasks/task_e_6895b528d0c88322af0426e1a70c7268