### PR TITLE
Refactor orchestrator to asynchronous event loop with WebSocket support

### DIFF
--- a/hypertrader/orchestrator.py
+++ b/hypertrader/orchestrator.py
@@ -1,11 +1,12 @@
 """Central orchestration for the trading system."""
 from __future__ import annotations
 
+import asyncio
 from dataclasses import dataclass
 from typing import Any, Dict, Optional
-import time
 
-from .bot import run
+from .bot import _run
+from .feeds.ccxt_ws import CCXTWebSocketFeed
 
 
 @dataclass
@@ -15,21 +16,49 @@ class TradingOrchestrator:
     Parameters
     ----------
     config : dict
-        Configuration passed directly to :func:`hypertrader.bot.run`.
+        Configuration passed directly to :func:`hypertrader.bot._run`.
     loop_interval : float, default ``60.0``
-        Seconds to sleep between iterations.
+        Seconds to sleep between iterations when not streaming.
     max_cycles : int, optional
         If provided, the loop stops after this many iterations.
+    use_websocket : bool, default ``True``
+        When ``True`` and both ``symbol`` and ``exchange`` are supplied in
+        ``config`` the orchestrator subscribes to a WebSocket ticker feed and
+        triggers a trading cycle on each update.  Falls back to a timed loop
+        otherwise.
     """
 
     config: Dict[str, Any]
     loop_interval: float = 60.0
     max_cycles: Optional[int] = None
+    use_websocket: bool = True
 
-    def run_loop(self) -> None:
-        """Execute the trading loop."""
+    async def _cycle(self) -> None:
+        """Run a single trading cycle."""
+        await _run(**self.config)
+
+    async def run_loop(self) -> None:
+        """Execute the trading loop using WebSocket events or timed sleeps."""
         cycles = 0
-        while self.max_cycles is None or cycles < self.max_cycles:
-            run(**self.config)
-            cycles += 1
-            time.sleep(self.loop_interval)
+        symbol = self.config.get("symbol")
+        exchange = self.config.get("exchange")
+
+        if self.use_websocket and isinstance(symbol, str) and exchange:
+            feed = CCXTWebSocketFeed(exchange, symbol.replace("-", "/"))
+            try:
+                async for _ in feed.stream():
+                    await self._cycle()
+                    cycles += 1
+                    if self.max_cycles is not None and cycles >= self.max_cycles:
+                        break
+            finally:
+                await feed.close()
+        else:
+            while self.max_cycles is None or cycles < self.max_cycles:
+                await self._cycle()
+                cycles += 1
+                await asyncio.sleep(self.loop_interval)
+
+    def start(self) -> None:
+        """Blocking entry point that starts the asyncio loop."""
+        asyncio.run(self.run_loop())

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -1,17 +1,18 @@
+import pytest
+
 from hypertrader.orchestrator import TradingOrchestrator
 
 
-def test_orchestrator_runs_once(monkeypatch):
-    calls = {
-        "count": 0,
-    }
+@pytest.mark.asyncio
+async def test_orchestrator_runs_once(monkeypatch):
+    calls = {"count": 0}
 
-    def fake_run(**kwargs):
+    async def fake_run(**kwargs):
         calls["count"] += 1
 
-    monkeypatch.setattr("hypertrader.orchestrator.run", fake_run)
+    monkeypatch.setattr("hypertrader.orchestrator._run", fake_run)
 
-    orch = TradingOrchestrator({"symbol": "BTC-USD"}, loop_interval=0.0, max_cycles=1)
-    orch.run_loop()
+    orch = TradingOrchestrator({"symbol": "BTC-USD"}, loop_interval=0.0, max_cycles=1, use_websocket=False)
+    await orch.run_loop()
 
     assert calls["count"] == 1


### PR DESCRIPTION
## Summary
- Replace blocking orchestrator loop with asyncio-based implementation
- Trigger trading cycles from CCXT WebSocket events by default and retain timed fallback
- Update orchestrator test for async interface

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6896362499fc8322ac10089f777aac14