### PR TITLE
Wire heartbeat safety and use native exchange websockets

### DIFF
--- a/hypertrader/execution/ccxt_executor.py
+++ b/hypertrader/execution/ccxt_executor.py
@@ -23,6 +23,7 @@ async def place_order(
     params: dict | None = None,
     post_only: bool = False,
     reduce_only: bool = False,
+    time_in_force: str | None = None,
 ):
     """Place an order after validating venue limits.
 
@@ -46,6 +47,8 @@ async def place_order(
     reduce_only : bool, optional
         When ``True`` the order is submitted with a reduce-only flag.  Raises
         ``RuntimeError`` if unsupported by the venue.
+    time_in_force : str | None, optional
+        Optional time-in-force directive (e.g. ``"GTC"`` or ``"IOC"``).
     """
 
     params = params.copy() if params else {}
@@ -53,14 +56,27 @@ async def place_order(
         client_id = uuid.uuid4().hex
     params.setdefault("clientOrderId", client_id)
 
-    if post_only:
-        if not ex.has.get("createPostOnlyOrder", False):
-            raise RuntimeError("post-only orders not supported")
-        params["postOnly"] = True
-    if reduce_only:
-        if not ex.has.get("createReduceOnlyOrder", False):
-            raise RuntimeError("reduce-only orders not supported")
-        params["reduceOnly"] = True
+    ex_id = getattr(ex, "id", "")
+    if ex_id in {"binance", "bybit", "okx"}:
+        # explicit mappings for common venues
+        if post_only:
+            tif = {"binance": "GTX", "bybit": "PostOnly", "okx": "post_only"}[ex_id]
+            params["timeInForce"] = tif
+        elif time_in_force:
+            params["timeInForce"] = time_in_force
+        if reduce_only:
+            params["reduceOnly"] = True
+    else:
+        if post_only:
+            if not ex.has.get("createPostOnlyOrder", False):
+                raise RuntimeError("post-only orders not supported")
+            params["postOnly"] = True
+        if reduce_only:
+            if not ex.has.get("createReduceOnlyOrder", False):
+                raise RuntimeError("reduce-only orders not supported")
+            params["reduceOnly"] = True
+        if time_in_force:
+            params["timeInForce"] = time_in_force
 
     await ex.load_markets()
     market = ex.market(symbol)
@@ -86,3 +102,15 @@ async def cancel_order(symbol: str, order_id: str):
 
     await ex.load_markets()
     return await ex.cancel_order(order_id, symbol)
+
+
+async def cancel_all(symbol: str | None = None):
+    """Cancel all outstanding orders optionally filtered by symbol."""
+
+    await ex.load_markets()
+    if ex.has.get("cancelAllOrders", False):
+        return await ex.cancel_all_orders(symbol)
+    open_orders = await ex.fetch_open_orders(symbol)
+    for order in open_orders:
+        await ex.cancel_order(order["id"], order["symbol"])
+    return open_orders

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
     "vadersentiment (>=3.3.2,<4.0.0)",
     "prometheus-client (>=0.22.1,<0.23.0)",
     "fredapi (>=0.5.2,<0.6.0)",
+    "websockets (>=14.1,<16.0)",
 ]
 
 [project.optional-dependencies]

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,3 +21,4 @@ transformers==4.40.1
 python-dotenv==1.1.1
 ruff==0.4.5
 mypy==1.10.0
+websockets==15.0.1

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -47,19 +47,27 @@ def test_fetch_ohlcv_with_fallback(monkeypatch):
 
 
 def test_stream_ohlcv(monkeypatch):
-    class DummyExchange:
-        def __init__(self, *args, **kwargs):
+    class DummyFeed:
+        def __init__(self, exchange, symbol, heartbeat=30):
             pass
 
-        async def watch_ohlcv(self, symbol, timeframe):
-            return [0, 1, 1, 1, 1, 1]
+        async def stream(self):
+            yield {
+                "o": 1,
+                "h": 1,
+                "l": 1,
+                "c": 1,
+                "v": 1,
+            }
 
-    monkeypatch.setattr("ccxt.async_support.binance", DummyExchange)
+    monkeypatch.setattr(
+        "hypertrader.data.fetch_data.ExchangeWebSocketFeed", DummyFeed
+    )
 
     async def run():
         gen = stream_ohlcv("BTC/USDT")
         candle = await gen.__anext__()
-        assert candle[0] == 0
+        assert candle[1] == 1
 
     asyncio.run(run())
 


### PR DESCRIPTION
## Summary
- Switch data ingestion to exchange-native websockets and derive candles without ccxt.pro
- Map post-only/reduce-only/time-in-force flags for Binance, Bybit and OKX with a new `cancel_all` helper
- Cancel outstanding orders on websocket heartbeat failure and add websockets dependency

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68971478d270832287c32a37ea3a33ad