### PR TITLE
feat: stream exchange candles and persist orders

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ and steps required before high‑risk deployment.
 
 ## Features
 
-- Fetch OHLCV price data from cryptocurrency exchanges using [CCXT](https://github.com/ccxt/ccxt) REST APIs and stream real-time candles via free exchange WebSocket endpoints.
+- Fetch OHLCV price data from cryptocurrency exchanges using [CCXT](https://github.com/ccxt/ccxt) REST APIs and stream real-time candles via direct Binance/Bybit WebSocket endpoints (no CCXT Pro).
 - Compute technical indicators such as moving averages, EMA, SuperTrend, RSI, MACD, Bollinger Bands, VWAP, On-Balance Volume,
   ADX, Stochastic oscillator, Rate of Change, TWAP, CCI, Keltner Channels, exchange net flow, volatility clustering index,
   Fibonacci retracements, WaveTrend oscillator, multi-timeframe RSI, volume profile point of control, Ichimoku Cloud,
@@ -88,7 +88,7 @@ When not operating live, the bot writes decisions to `signal.json` for offline i
 
 ### Running the autonomous bot
 
-The `hypertrader.bot` module fetches data from supported exchanges via CCXT, optionally gathers news sentiment, and when run in live mode places orders directly via CCXT. When not live it writes a trading signal with calculated position size to `signal.json`. When multiple symbols are provided the bot will automatically trade the one with the highest recent volatility:
+The `hypertrader.bot` module fetches data from supported exchanges via CCXT REST and consumes live candles from direct exchange WebSockets. When run in live mode it places orders via CCXT. When not live it writes a trading signal with calculated position size to `signal.json`. When multiple symbols are provided the bot will automatically trade the one with the highest recent volatility:
 
 ```bash
 python -m hypertrader.bot BTC-USD ETH-USD --account_balance 10000 --risk_percent 5 \

--- a/hypertrader/data/order_store.py
+++ b/hypertrader/data/order_store.py
@@ -1,0 +1,43 @@
+import sqlite3
+from pathlib import Path
+from typing import Iterable, Tuple
+
+class OrderStore:
+    """Tiny SQLite-backed store for open orders."""
+
+    def __init__(self, path: str | Path = "orders.db") -> None:
+        self.path = Path(path)
+        self.conn = sqlite3.connect(self.path)
+        self._init_db()
+
+    def _init_db(self) -> None:
+        self.conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS orders (
+                id TEXT PRIMARY KEY,
+                symbol TEXT NOT NULL,
+                side TEXT NOT NULL,
+                volume REAL NOT NULL,
+                ts REAL NOT NULL
+            )
+            """
+        )
+        self.conn.commit()
+
+    def record(self, order_id: str, symbol: str, side: str, volume: float, ts: float) -> None:
+        self.conn.execute(
+            "INSERT OR REPLACE INTO orders(id, symbol, side, volume, ts) VALUES (?,?,?,?,?)",
+            (order_id, symbol, side, volume, ts),
+        )
+        self.conn.commit()
+
+    def remove(self, order_id: str) -> None:
+        self.conn.execute("DELETE FROM orders WHERE id=?", (order_id,))
+        self.conn.commit()
+
+    def fetch_all(self) -> Iterable[Tuple[str, str, str, float, float]]:
+        cur = self.conn.execute("SELECT id, symbol, side, volume, ts FROM orders")
+        return cur.fetchall()
+
+    def close(self) -> None:
+        self.conn.close()

--- a/hypertrader/orchestrator.py
+++ b/hypertrader/orchestrator.py
@@ -2,11 +2,15 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 from dataclasses import dataclass
 from typing import Any, Dict, Optional
 
+import pandas as pd
+
 from .bot import _run
 from .feeds.exchange_ws import ExchangeWebSocketFeed
+from .data.fetch_data import stream_ohlcv
 from .execution.ccxt_executor import cancel_all
 
 
@@ -34,9 +38,9 @@ class TradingOrchestrator:
     max_cycles: Optional[int] = None
     use_websocket: bool = True
 
-    async def _cycle(self) -> None:
+    async def _cycle(self, data: pd.DataFrame | None = None) -> None:
         """Run a single trading cycle."""
-        await _run(**self.config)
+        await _run(data=data, **self.config)
 
     async def run_loop(self) -> None:
         """Execute the trading loop using WebSocket events or timed sleeps."""
@@ -46,11 +50,17 @@ class TradingOrchestrator:
 
         if self.use_websocket and isinstance(symbol, str) and exchange:
             ws_symbol = symbol
+            ccxt_symbol = symbol.replace("-", "/") if isinstance(symbol, str) else symbol
             if exchange.lower() == "binance":
                 ws_symbol = symbol.replace("-", "").replace("/", "").lower()
             elif exchange.lower() == "bybit":
                 ws_symbol = symbol.replace("/", "").replace("-", "").upper()
             feed = ExchangeWebSocketFeed(exchange, ws_symbol)
+            candle_queue: asyncio.Queue[list[float]] = asyncio.Queue()
+            candle_task = asyncio.create_task(
+                stream_ohlcv(ccxt_symbol, exchange_name=exchange, queue=candle_queue)
+            )
+            candles: list[list[float]] = []
             try:
                 async for msg in feed.stream():
                     if msg is None:
@@ -60,11 +70,26 @@ class TradingOrchestrator:
                         except Exception:
                             pass
                         continue
-                    await self._cycle()
+                    try:
+                        candle = candle_queue.get_nowait()
+                    except asyncio.QueueEmpty:
+                        continue
+                    candles.append(candle)
+                    candles = candles[-1000:]
+                    df = pd.DataFrame(
+                        candles,
+                        columns=["timestamp", "open", "high", "low", "close", "volume"],
+                    )
+                    df["timestamp"] = pd.to_datetime(df["timestamp"], unit="ms")
+                    df.set_index("timestamp", inplace=True)
+                    await self._cycle(df)
                     cycles += 1
                     if self.max_cycles is not None and cycles >= self.max_cycles:
                         break
             finally:
+                candle_task.cancel()
+                with contextlib.suppress(Exception):
+                    await candle_task
                 await feed.close()
         else:
             while self.max_cycles is None or cycles < self.max_cycles:


### PR DESCRIPTION
## Summary
- Stream live OHLCV candles from exchange WebSockets via orchestrator
- Persist open orders in a lightweight SQLite store
- Clarify in README that WebSocket data comes from direct exchange feeds, not CCXT Pro

## Testing
- `ruff hypertrader/bot.py hypertrader/orchestrator.py hypertrader/data/order_store.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68974d548d5c83229298088be67ffc64