### PR TITLE
feat: normalize ws events and async keepalive

### DIFF
--- a/hypertrader/data/oms_store.py
+++ b/hypertrader/data/oms_store.py
@@ -54,7 +54,8 @@ class OMSStore:
                 qty REAL NOT NULL,
                 price REAL NOT NULL,
                 fee REAL DEFAULT 0,
-                ts REAL NOT NULL
+                ts REAL NOT NULL,
+                UNIQUE(order_id, ts, qty, price, fee)
             )
             """
         )
@@ -113,7 +114,7 @@ class OMSStore:
         self, order_id: str, qty: float, price: float, fee: float, ts: float
     ) -> None:
         await self._enqueue(
-            "INSERT INTO fills(order_id, qty, price, fee, ts) VALUES (?,?,?,?,?)",
+            "INSERT OR IGNORE INTO fills(order_id, qty, price, fee, ts) VALUES (?,?,?,?,?)",
             (order_id, qty, price, fee, ts),
         )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
     "vadersentiment (>=3.3.2,<4.0.0)",
     "vectorbt (>=0.28.0,<0.29.0)",
     "websockets (>=14.1,<16.0)",
+    "httpx (>=0.28.1,<0.29.0)",
 ]
 
 [project.optional-dependencies]

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,7 @@ pytest-asyncio==1.1.0
 python-dotenv==1.1.1
 pyyaml==6.0.1
 requests==2.32.3
+httpx==0.28.1
 ruff==0.4.5
 scikit-learn==1.4.2
 stable-baselines3==2.3.0

--- a/tests/test_private_ws.py
+++ b/tests/test_private_ws.py
@@ -1,8 +1,5 @@
 import asyncio
-import time
-
 import pytest
-import requests
 import websockets
 
 from hypertrader.feeds.private_ws import PrivateWebSocketFeed
@@ -27,28 +24,35 @@ class FakeResp:
 
 @pytest.mark.asyncio
 async def test_listen_key_keepalive(monkeypatch, tmp_path):
-    calls = {"put": 0}
+    class DummyClient:
+        def __init__(self):
+            self.calls = {"put": 0}
 
-    def fake_post(url, headers):
-        return FakeResp({"listenKey": "abc"})
+        async def post(self, url, headers=None):
+            return FakeResp({"listenKey": "abc"})
 
-    def fake_put(url, params, headers):
-        calls["put"] += 1
-        return FakeResp()
+        async def put(self, url, params=None, headers=None):
+            self.calls["put"] += 1
+            return FakeResp()
+
+        async def delete(self, url, params=None, headers=None):
+            return FakeResp()
+
+        async def aclose(self):
+            pass
 
     async def fake_connect(url):
         return DummyWS()
-
-    monkeypatch.setattr(requests, "post", fake_post)
-    monkeypatch.setattr(requests, "put", fake_put)
-    monkeypatch.setattr(websockets, "connect", lambda url: fake_connect(url))
 
     store = OMSStore(tmp_path / "db.sqlite")
     feed = PrivateWebSocketFeed(
         "binance", store, "k", "s", listen_key_refresh=0.1
     )
+    feed._http = DummyClient()
+    monkeypatch.setattr(websockets, "connect", lambda url: fake_connect(url))
+
     await feed._connect()
     await asyncio.sleep(0.25)
-    assert calls["put"] >= 1
+    assert feed._http.calls["put"] >= 1
     await feed.close()
     await store.close()

--- a/tests/test_private_ws_binance_futures.py
+++ b/tests/test_private_ws_binance_futures.py
@@ -39,3 +39,66 @@ async def test_store_updates_from_futures_event(tmp_path):
     assert price == pytest.approx(10000)
     assert fee == pytest.approx(0.00001)
     await store.close()
+
+
+@pytest.mark.asyncio
+async def test_partial_fill_sequence(tmp_path):
+    store = OMSStore(tmp_path / "db.sqlite")
+    feed = PrivateWebSocketFeed("binance", store, "k", "s", market="futures")
+    await store.record_order("1", "cid", "BTCUSDT", "BUY", 0.002, 10000, "NEW", 0)
+    partial = {
+        "e": "ORDER_TRADE_UPDATE",
+        "E": 1000,
+        "o": {
+            "s": "BTCUSDT",
+            "c": "cid",
+            "i": 1,
+            "X": "PARTIALLY_FILLED",
+            "S": "BUY",
+            "q": "0.002",
+            "p": "10000",
+            "l": "0.001",
+            "L": "10000",
+            "n": "0.00001",
+            "T": 1100,
+            "x": "TRADE",
+        },
+    }
+    final = {
+        "e": "ORDER_TRADE_UPDATE",
+        "E": 2000,
+        "o": {
+            "s": "BTCUSDT",
+            "c": "cid",
+            "i": 1,
+            "X": "FILLED",
+            "S": "BUY",
+            "q": "0.002",
+            "p": "10000",
+            "l": "0.001",
+            "L": "10000",
+            "n": "0.00001",
+            "T": 2100,
+            "x": "TRADE",
+        },
+    }
+    await feed._handle_binance(partial)
+    await feed._handle_binance(final)
+    cur = store.conn.execute("SELECT status FROM orders WHERE id=?", ("1",))
+    assert cur.fetchone()[0] == "FILLED"
+    cur = store.conn.execute("SELECT SUM(qty) FROM fills WHERE order_id=?", ("1",))
+    assert cur.fetchone()[0] == pytest.approx(0.002)
+    await store.close()
+
+
+@pytest.mark.asyncio
+async def test_duplicate_event_idempotent(tmp_path):
+    store = OMSStore(tmp_path / "db.sqlite")
+    feed = PrivateWebSocketFeed("binance", store, "k", "s", market="futures")
+    await store.record_order("123456789", "cid", "BTCUSDT", "BUY", 0.001, 10000, "NEW", 0)
+    ev = load_event()
+    await feed._handle_binance(ev)
+    await feed._handle_binance(ev)
+    cur = store.conn.execute("SELECT COUNT(*) FROM fills WHERE order_id=?", ("123456789",))
+    assert cur.fetchone()[0] == 1
+    await store.close()


### PR DESCRIPTION
## Summary
- replace blocking `requests` with `httpx.AsyncClient` and unify Binance order IDs
- normalize WebSocket timestamps to epoch seconds and dedupe fills
- add futures partial-fill and duplicate event tests, plus async keepalive test

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68988276d2d48322bb6127a2d907b271